### PR TITLE
more permissive normalization strategy

### DIFF
--- a/scripts/ingest_startgg.py
+++ b/scripts/ingest_startgg.py
@@ -5,6 +5,7 @@ import pprint
 import re
 import requests
 import sys
+import unicodedata
 
 from pytubefix import Playlist
 from typing import cast
@@ -72,7 +73,23 @@ def get_vod_data(set_obj, tournament_name: str, date: str, video_url: str):
     }
 
 def normalize(string: str):
-    return re.sub(r'[^a-z0-9!#$%&\'+,;=@^`{}~]', '', string.lower())
+    # normalize to compatibility characters, decompose combining characters, unicode lowercase
+    normalized = unicodedata.normalize("NFKD", unicodedata.normalize("NFKD", string).casefold())
+
+    # remove combining characters like diacritics
+    normalized_non_combining_chars = []
+    for c in list(normalized):
+        if (unicodedata.combining(c) == 0):
+            normalized_non_combining_chars.append(c)
+
+    # remove chars that are illegal in filenames (mostly on windows)
+    sub1 = re.sub(r'[\<\>\:"\/\\|\?\*]', '', "".join(normalized_non_combining_chars))
+
+    # replace chars that YT replaces with space
+    sub2 = re.sub(r'[.\-_]', ' ', sub1)
+
+    # remove chars that YT removes
+    return re.sub(r'[\(\)\[\]]', '', sub2)
 
 def get_tournament_sets_name_and_date(slug: str):
     tournament_response = requests.get(f"https://api.start.gg/tournament/{slug}?expand[]=groups&expand[]=phase").json()
@@ -86,7 +103,8 @@ def get_tournament_sets_name_and_date(slug: str):
     }
     sets = []
     for group in tournament_response["entities"]["groups"]:
-        group_response = requests.get(f"https://api.start.gg/phase_group/{group["id"]}?expand[]=sets&expand[]=entrants").json()
+        group_id = group["id"]
+        group_response = requests.get(f"https://api.start.gg/phase_group/{group_id}?expand[]=sets&expand[]=entrants").json()
         if "entrants" not in group_response["entities"]:
             continue
         entrant_id_to_gamer_tags = {

--- a/scripts/ingest_startgg.py
+++ b/scripts/ingest_startgg.py
@@ -209,7 +209,7 @@ def set_tournament_vod_urls(slug: str, videos: list[tuple[str, str]], api_key: s
             requests.append(startgg_gql.get_set_vod_request(set_obj["id"], video_url))
     original_requests_len = len(requests)
     if dry_run:
-        print(f"{len(requests)} new VOD URLs matched but not set in {slug}")
+        print(f"dry run: {len(requests)} new VOD URLs matched but not set in {slug}")
     else:
         while len(requests) > 0:
             # no rate handling because you'd need 40,000 VODs to exceed

--- a/scripts/ingest_startgg.py
+++ b/scripts/ingest_startgg.py
@@ -8,6 +8,7 @@ import sys
 import unicodedata
 
 from pytubefix import Playlist
+from sanitize_filename import sanitize
 from typing import cast
 from zoneinfo import ZoneInfo
 
@@ -82,14 +83,14 @@ def normalize(string: str):
         if (unicodedata.combining(c) == 0):
             normalized_non_combining_chars.append(c)
 
-    # remove chars that are illegal in filenames (mostly on windows)
-    sub1 = re.sub(r'[\<\>\:"\/\\|\?\*]', '', "".join(normalized_non_combining_chars))
+    # sanitize for filename legality
+    sanitized = sanitize("".join(normalized_non_combining_chars))
 
     # replace chars that YT replaces with space
-    sub2 = re.sub(r'[.\-_]', ' ', sub1)
+    yt_space_replaced = re.sub(r'[.\-_]', ' ', sanitized)
 
     # remove chars that YT removes
-    return re.sub(r'[\(\)\[\]]', '', sub2)
+    return re.sub(r'[\(\)\[\]]', '', yt_space_replaced)
 
 def get_tournament_sets_name_and_date(slug: str):
     tournament_response = requests.get(f"https://api.start.gg/tournament/{slug}?expand[]=groups&expand[]=phase").json()

--- a/scripts/ingest_startgg.py
+++ b/scripts/ingest_startgg.py
@@ -106,7 +106,9 @@ def get_tournament_sets_name_and_date(slug: str):
     for group in tournament_response["entities"]["groups"]:
         group_id = group["id"]
         group_response = requests.get(f"https://api.start.gg/phase_group/{group_id}?expand[]=sets&expand[]=entrants").json()
-        if "entrants" not in group_response["entities"]:
+        if "sets" not in group_response["entities"] or len(group_response["entities"]["sets"]) == 0:
+            continue
+        if "entrants" not in group_response["entities"] or len(group_response["entities"]["entrants"]) == 0:
             continue
         entrant_id_to_gamer_tags = {
             entrant["id"]: [

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,4 @@
 google-api-python-client==2.170.0
 gql[all]==3.5.3
 pytubefix==9.2.0
+sanitize-filename==1.2.0


### PR DESCRIPTION
- unicode normalization according to https://docs.python.org/3/howto/unicode.html#comparing-strings
- removing combining characters like diacritics (IE é -> e)
- plus blacklist of characters forbidden in filenames by OS and YT

this lets Ble$$é match Ble$$e for example
please feel free to test for regressions in known playlists, it passes my 2 offstream Unranked playlists, and improves for the main stream Unranked playlist

also for whatever reason on my other machine, it didn't like `group["id"]` inside double quote format string